### PR TITLE
Pass ramlev tests before generating mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ GETTING STARTED
 ---
   - Yo need to define a RAML file like this: [definition.raml]
   - Import the json-schema file or define it inside the raml file.
-  -
+  - It's better if the RAML is validated by [ramlev][].
 
+[ramlev]: https://github.com/cybertk/ramlev.git
 
 HOW TO USE RAML MOCKER
 ---


### PR DESCRIPTION
**raml-mocker** is awesome for automated REST API testing. I tried to integrated it into a CI process before [ramlev][], which is a example validator of RAML. **ramlev** will ensure the RAML is able to mock with **raml-mocker** if all tests passed.

[ramlev]: https://github.com/cybertk/ramlev