### PR TITLE
Add ability to render "example" if it's available for json response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,9 @@ function getRamlRequestsToMockMethods(definition, uri, formats, callback) {
             var currentMockDefaultCode = null;
             _.each(responsesMethodByCode, function (reqDefinition) {
                 methodMocker.addResponse(reqDefinition.code, function () {
+                    if (reqDefinition.example) {
+                        return reqDefinition.example;
+                    }
                     if (reqDefinition.schema) {
                         return schemaMocker(reqDefinition.schema, formats);
                     } else {
@@ -149,26 +152,24 @@ function getRamlRequestsToMockMethods(definition, uri, formats, callback) {
 function getResponsesByCode(responses) {
     var responsesByCode = [];
     _.each(responses, function (response, code) {
+        var body = response.body && response.body['application/json'];
+        var schema = null;
+        var example = null;
         if (!_.isNaN(Number(code))) {
             code = Number(code);
-            if (response.body && response.body['application/json'] && response.body['application/json'].schema) {
+            if (body) {
                 try {
-                    var schema = JSON.parse(response.body['application/json'].schema);
-                    if (schema) {
-                        responsesByCode.push({
-                            code: code,
-                            schema: schema
-                        });
-                    }
+                    schema = body.schema && JSON.parse(body.schema);
+                    example = body.example && JSON.parse(body.example);
                 } catch (exception) {
                     console.log(exception.stack);
                 }
-            } else {
-                responsesByCode.push({
-                    code: code,
-                    schema: null
-                });
             }
+            responsesByCode.push({
+                code: code,
+                schema: schema,
+                example: example
+            });
         }
     });
     return responsesByCode;

--- a/test/raml/.gitignore
+++ b/test/raml/.gitignore
@@ -1,0 +1,14 @@
+**/target/
+**/node_modules/
+launchpad-jetty/backbase/data/
+launchpad-jetty/webapps/demo-services.war
+launchpad-jetty/webapps/portalserver.war
+launchpad-jetty/work/
+*.swp
+*.swo
+*~
+launchpad-bundles/launchpad-theme/themes/**/css/*
+launchpad-bundles/node
+launchpad-bundles/launchpad-theme/node
+launchpad-jetty/activemq/
+launchpad-jetty/webapps/distributed-services-web.war

--- a/test/raml/definition.raml
+++ b/test/raml/definition.raml
@@ -21,4 +21,13 @@ schemas:
           201:
             body:
               schema: objectDef
+    /example.json:
+      get:
+        description: |
+          Render JSON example
+        responses:
+          200:
+            body:
+              application/json:
+                example: !include examples/example.json
 

--- a/test/raml/examples/example.json
+++ b/test/raml/examples/example.json
@@ -1,0 +1,27 @@
+{
+  "foo": {
+    "bar": {
+      "attr": "val",
+      "properties": [{
+          "property": {
+            "name": "name",
+            "label": "label",
+            "value": {
+              "type": "string",
+              "@text": "Example"
+            }
+          }
+        },{
+          "property": {
+            "name": "type",
+            "label": "label",
+            "value": {
+              "type": "string",
+              "@text": "json"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/ramlTest.js
+++ b/test/ramlTest.js
@@ -12,6 +12,8 @@ ramlMocker.generate({
 }, function (methods) {
     console.log(methods);
     _.each(methods, function (m) {
-        console.log(m.mock());
+        console.log(m.mock(function(reqDefinition, response){
+            return reqDefinition.example ? reqDefinition.example : response;
+        }));
     });
 });


### PR DESCRIPTION
Hello,

**Prehistory:**
We are using RAML format for documentation and we use to have separate service which was implementing same API for demo purposes. But it become kind of bottleneck for front-end developers to mock new data since it involves back-end part to be in place.

After that we started using services like https://anypoint.mulesoft.com and http://apiary.io/ to rapidly mock new APIs and responses.

That approach was not very handy for standalone development and collaboration. It would be much better to keep all RAML files under the source control and run mock server locally with no dependencies on the real backend and 3rd party services.

After some research I found your module which works perfectly with schemas, but unfortunately does not support rendering of the "example" output.

With few modifications it become possible to use your module for that.

Can you please review and possible release a new npm version for this update, so we can all switch to this version.

Thank you!
