### PR TITLE
Add support for canonical dereferencing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "async": "^0.9.0",
         "faker": "^1.1.0",
         "lodash": "^2.4.1",
-        "raml-parser": "^0.8.7"
+        "raml-parser": "^0.8.7",
+        "urllib-sync": "^1.1.0"
     }
 }


### PR DESCRIPTION
I wanted to be able to use canonical dereferencing by the id attribute of the parent schema when it includes a reference to another schema hosted on the same server path. 

Spec reference. Short version: id is a URI to the current schema, any referenced schema are assumed to be relative to that id path excluding the schema document name.
http://json-schema.org/latest/json-schema-core.html#anchor30

There may be prettier ways to do this, but I'm not an avid node developer. 

This will also cache the schemas documents based on their fully qualified URI. 