### PR TITLE
Bugfix for numbermocker when min/max exactly zero

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -211,8 +211,8 @@ var SchemaMocker = function () {
                 }
                 ret = schema.multipleOf * _.random(multipleMin, multipleMax, floating);
             } else {
-                var minimum = schema.minimum || -99999999999;
-                var maximum = schema.maximum || 99999999999;
+                var minimum = schema.minimum !== undefined ? schema.minimum : -99999999999;
+                var maximum = schema.maximum !== undefined ? schema.maximum : 99999999999;
                 var gap = maximum - minimum;
                 /**
                  *  - min: 0.000006


### PR DESCRIPTION
Check on minimum and/or maximum failed in the numbermocker when the value was exactly zero. Gap calculation was wrong causing faulty mocking values for your number or integer types. Fixed by adding undefined check on the values