### PR TITLE
Feature/support base uri parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,9 +185,33 @@ function getResponsesByCode(responses) {
 function getRamlRequestsToMockResources(definition, uri, formats, callback) {
     var requestsToMock = [];
     var baseUri = '';
-    if (definition.baseUri) {
+
+    if (definition.baseUri && definition.baseUriParameters) {
+      // extra the variables from the baseUri
+      var uriElems = definition.baseUri.match(/{[a-zA-Z]+}/g);
+
+      // get the default variable value from the baseUriParameters
+      var tempBaseUri = definition.baseUri;
+      uriElems.map(function (elem) { // e.g. elem == '{host}'
+        var strippedElem = elem.replace("{","").replace("}","");
+        var elemValue = definition.baseUriParameters[strippedElem].default;
+        if (!elemValue) {
+          // if not available, look into definition for a value
+          elemValue = definition[strippedElem];
+        }
+        if (elemValue) {
+          tempBaseUri = tempBaseUri.replace( new RegExp(elem, 'g'), elemValue);
+        } else {
+          console.log("No value found for "+elem);
+        }
+      });
+      baseUri = url.parse(tempBaseUri).pathname;
+    }
+
+    if (definition.baseUri && !definition.baseUriParameters) {
         baseUri = url.parse(definition.baseUri).pathname;
     }
+    
     async.each(definition.resources, function (def, cb) {
         getRamlRequestsToMock(def, baseUri + uri, formats, function (reqs) {
             requestsToMock = _.union(requestsToMock, reqs);

--- a/test/raml/baseUriParams.raml
+++ b/test/raml/baseUriParams.raml
@@ -1,0 +1,23 @@
+#%RAML 0.8
+title: TEST_Definition
+version: v1
+baseUri: http://{host}:{hostport}/api/{version}/
+baseUriParameters:
+  host:
+    default: localhost
+  hostport:
+    default: 8080
+
+mediaType: application/json
+
+/baseUri:
+  /example.json:
+    get:
+      description: |
+        Render JSON example
+      responses:
+        200:
+          body:
+            application/json:
+              example: !include examples/example.json
+        204:

--- a/test/schemaTest.js
+++ b/test/schemaTest.js
@@ -36,7 +36,7 @@ var schema = {
 
 var formats = {
     foo: function foo(Faker, schema) {
-        return Faker.Name.firstName();
+        return Faker.name.firstName();
     },
     Bar: function foo(Faker, schema) {
         return 'BAR';


### PR DESCRIPTION
Added support for baseUriParameters.

Case: we're using raml-mocker-server to mock our api, but since we added 'baseUriParameters' the mocker server did not work anymore. With this fix, it works again.
Would appreciate if this gets merged into raml-mocker.