### PR TITLE
Catch uncaught errors when parsing RAML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ function generateFromFiles(files, parserOptions, formats, callback) {
                 requestsToMock = _.union(requestsToMock, reqs);
                 cb();
             });
-        }, function (error) {
+        }).catch(function (error) {
             cb('Error parsing: ' + error);
         });
     }, function (err) {


### PR DESCRIPTION
The error function in then only catches faults happening inside
`aml.loadFile(file, parserOptions)`, not in `getRamlRequestsToMock()`. Using
a normal .catch() instead will also surface these errors.

PS! I just spent many hours trying to figure out why it silently failed :(
